### PR TITLE
Enable SMTP login to be different from the email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ nano config.json
   "token": "<Discord Bot Token>",
   "clientId": "<Discord Bot Client ID>",
   "email": "<Email Address>",
+  "username": "<Mail Server Username>",
   "password": "<Email Password>",
   "smtpHost": "<SMTP Server>",
   "isGoogle": <true/false>,

--- a/src/mail/MailSender.js
+++ b/src/mail/MailSender.js
@@ -1,4 +1,4 @@
-const {smtpHost, email, password, isGoogle, isSecure, smtpPort} = require("../../config.json");
+const {smtpHost, email, username, password, isGoogle, isSecure, smtpPort} = require("../../config.json");
 const nodemailer = require("nodemailer");
 const smtpTransport = require("nodemailer-smtp-transport");
 const {defaultLanguage, getLocale} = require("../Language");
@@ -11,7 +11,7 @@ module.exports = class MailSender {
         let nodemailerOptions = {
             host: smtpHost,
             auth: {
-                user: email,
+                user: username,
                 pass: password
             }
         }
@@ -26,7 +26,7 @@ module.exports = class MailSender {
     async sendEmail(toEmail, code, name, message, emailNotify, callback) {
         await database.getServerSettings(this.userGuilds.get(message.author.id).id, serverSettings => {
             const mailOptions = {
-                from: email,
+                from: '"Email Verification Bot ✉️" <'+ email +'>',
                 to: toEmail,
                 subject: name + ' Discord Email Verification',
                 text: getLocale(serverSettings.language, "emailText", name, code)

--- a/src/mail/MailSender.js
+++ b/src/mail/MailSender.js
@@ -1,8 +1,13 @@
-const {smtpHost, email, username, password, isGoogle, isSecure, smtpPort} = require("../../config.json");
+const {smtpHost, email, password, isGoogle, isSecure, smtpPort} = require("../../config.json");
+
 const nodemailer = require("nodemailer");
 const smtpTransport = require("nodemailer-smtp-transport");
 const {defaultLanguage, getLocale} = require("../Language");
 const database = require("../database/Database");
+
+if (typeof username === 'undefined') {
+    const username = email;
+}
 
 module.exports = class MailSender {
     constructor(userGuilds, serverStatsAPI) {


### PR DESCRIPTION
Several automated mail systems use a different username to the email address that is used for sending (examples include SendGrid, where the SMTP username is always `apikey`, or Postal, which uses `<organisation>/<mailserver>`. 

This patch provides an additional optional line in the config file to set custom usernames, while keeping existing configurations working.