### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:19
+
+MAINTAINER docker@pshar.ma
+
+WORKDIR /usr/app/
+
+RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev  && rm -rf /var/lib/apt/lists/*
+
+COPY . /usr/app/
+
+RUN npm install
+
+CMD ["npm", "start"]


### PR DESCRIPTION
For users who would like to containerise this project, I have made a Dockerfile.

**Caveats:**
Currently, I have no way of making the database persistent. The only solution I can think of right now is:
1. Build & run the image
2. Run `sudo find / -type f -name "bot.db"` or your system's equivalent
3. Copy `bot.db` to a directory that isn't `Docker/overlay2`
4. Re-run the image, mounting the copied `bot.db` file to `/usr/app/bot.db` in the image using the volume flag.