### PR TITLE
Added wildcard support for blacklisted emails

### DIFF
--- a/src/bot/messageCreate.js
+++ b/src/bot/messageCreate.js
@@ -40,8 +40,18 @@ module.exports = async function (message, bot, userGuilds, userCodes, userTimeou
             return
         }
         const text = message.content
-        if (serverSettings.blacklist.some((element) => text.includes(element)))
+
+        let isBlacklisted = serverSettings.blacklist.some((pattern) => {
+            const regexPattern = pattern
+                .split('*')
+                .map(part => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))
+                .join('.*');
+            const regex = new RegExp(`^${regexPattern}$`);
+            return regex.test(text);
+        });
+        if (isBlacklisted)
             return await message.reply(getLocale(serverSettings.language, "mailBlacklisted"));
+
         let userTimeout = userTimeouts.get(message.author.id)
         if (!userTimeout) {
             userTimeout = new UserTimeout()

--- a/src/commands/blacklist.js
+++ b/src/commands/blacklist.js
@@ -14,16 +14,20 @@ module.exports = {
         const blacklist = interaction.options.getString('email');
         await database.getServerSettings(interaction.guildId, async serverSettings => {
             if (!blacklist) {
-                await interaction.reply("Blacklisted emails:\n" + serverSettings.blacklist.join(", "));
+                await interaction.reply(
+                    "Blacklisted emails:\n" +
+                    serverSettings.blacklist.join(", ").replaceAll("*", "\\*")
+                );
             } else if (blacklist === "-") {
                 serverSettings.blacklist=[];
                 database.updateServerSettings(interaction.guildId, serverSettings);
                 await interaction.reply("Blacklist cleared!");
             }
             else {
-                const newBlacklists = blacklist.split(",").map(name=> name.trim())
-                const blacklistedNames = (format = false) => serverSettings.blacklist
-                    .concat(format ? newBlacklists.map(v=> `**${v}**`) : newBlacklists);
+                const newBlacklists = blacklist.split(",").map(name => name.trim())
+                const blacklistedNames = (format = false) =>
+                    (format ? serverSettings.blacklist.map(b => b.replaceAll("*", "\\*")) : serverSettings.blacklist)
+                        .concat(format ? newBlacklists.map(v => `**${v.replaceAll("*", "\\*")}**`) : newBlacklists);
                 await interaction.reply("Added:\n" + blacklistedNames(true).join(", "));
                 serverSettings.blacklist = blacklistedNames();
                 database.updateServerSettings(interaction.guildId, serverSettings);

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -16,7 +16,7 @@ module.exports = {
                 response += "Message Found: \:x: \n"
             }
             response += "Domains: " + serverSettings.domains.toString().replaceAll(",", "|").replaceAll("*", "\\*") + "\n"
-            response += "Blacklisted: " + serverSettings.blacklist.toString().replaceAll(",", "|") + "\n"
+            response += "Blacklisted: " + serverSettings.blacklist.toString().replaceAll(",", "|").replaceAll("*", "\\*") + "\n"
             let roleVerified = interaction.guild.roles.cache.find(r => r.id === serverSettings.verifiedRoleName)
             if (roleVerified === undefined) {
                 response += "Verified role can not be found!\n"


### PR DESCRIPTION
There's no wildcard support for blacklisted emails, so I added them.
I tested these out: `/blacklist email:*+*@*,*(*@*,*)*@*`, although someone else should check if this doesn't break anything.